### PR TITLE
Dev: applicant auth 구현

### DIFF
--- a/chanel/admin/domain/admin.py
+++ b/chanel/admin/domain/admin.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import Type
 
-from common.client.redis import RedisConnection
-from common.domain.entity import BaseEntityClass
+from chanel.common.client.redis import RedisConnection
+from chanel.common.domain.entity import BaseEntityClass
 
 
 @dataclass
@@ -19,11 +19,14 @@ class Admin(BaseEntityClass):
         return f"chanel:admin:refresh:{self.refresh_token}"
 
     @classmethod
-    def data_to_entity(cls, admin_id: str, refresh_token: str):
-        return Admin(
-            admin_id.split(":")[3],
-            refresh_token.split(":")[3]
-        )
+    def data_to_entity(cls, admin_id, refresh_token):
+        if type(admin_id) == bytes:
+            admin_id = admin_id.split(b':')[3].decode()
+
+        if type(refresh_token) == bytes:
+            refresh_token = refresh_token.split(b':')[3].decode()
+
+        return Admin(admin_id, refresh_token)
 
 
 class AdminCacheRepository:

--- a/chanel/admin/service/admin.py
+++ b/chanel/admin/service/admin.py
@@ -66,7 +66,7 @@ class AdminService:
 
         if saved and refresh == saved.refresh_token:
             await self.cache_repo.delete(saved)
-            return json(dict(msg="logout succeed"), 202)
+            return json(dict(msg="logout succeed"), 200)
 
         else:
             raise Forbidden("incorrect refresh token")

--- a/chanel/admin/service/admin.py
+++ b/chanel/admin/service/admin.py
@@ -1,12 +1,9 @@
-from datetime import timedelta
 from sanic.response import json
 from sanic_jwt_extended import create_refresh_token, create_access_token
-from werkzeug.security import generate_password_hash
 
-from chanel.admin.domain.admin import AdminCacheRepository
+from chanel.admin.domain.admin import AdminCacheRepository, Admin
 from chanel.common.exception import Forbidden, BadRequest
 from chanel.common.external_sevice import ExternalServiceRepository
-from chanel.common.client.vault import settings
 
 
 class AdminService:
@@ -19,16 +16,21 @@ class AdminService:
 
     async def login(self, request):
         admin_id = request.json.get("admin_id")
-        password = generate_password_hash(request.json.get("password"))
+        password = request.json.get("password")
 
-        authorized = await self.external_repo.get_admin_auth_from_gateway(admin_id, password)
+        authorized = await self.external_repo.get_admin_auth_from_hermes(admin_id, password)
+        admin_info = await self.external_repo.get_admin_info_from_hermes(admin_id) if authorized else None
 
-        if authorized:
-            access = await create_access_token(identity=admin_id, role="ADMIN", app=request.app)
-            refresh = await create_refresh_token(
-                identity=admin_id,
-                expires_delta=timedelta(days=settings.jwt_refresh_expire),
-                app=request.app
+        if authorized and admin_info:
+            saved_refresh = await self.cache_repo.get_by_id(admin_id)
+            if saved_refresh:
+                await self.cache_repo.delete(saved_refresh)
+
+            access = await create_access_token(identity=admin_id, role=admin_info["admin_type"], app=request.app)
+            refresh = await create_refresh_token(identity=admin_id, app=request.app)
+
+            await self.cache_repo.save(
+                Admin(admin_id, refresh), int(request.app.config.JWT_REFRESH_TOKEN_EXPIRES.total_seconds())
             )
 
             return json(dict(msg="login success", access=access, refresh=refresh), 201)
@@ -37,25 +39,34 @@ class AdminService:
             raise Forbidden("can't find match admin info")
 
     async def refresh(self, request):
-        refresh = request.headers.get("X-Refresh-Token")
-        saved = await self.cache_repo.get_by_refresh(refresh=refresh.split("Bearer ")[1])
-        admin_info = await self.external_repo.get_admin_info_from_gateway(saved.key) if saved else None
+        try:
+            refresh = request.headers.get("X-Refresh-Token").split("Bearer ")[1]
+        except IndexError:
+            raise BadRequest("missing 'Bearer '")
+
+        saved = await self.cache_repo.get_by_refresh(refresh)
+
+        admin_info = await self.external_repo.get_admin_info_from_hermes(saved.admin_id) if saved else None
         role = admin_info["admin_type"] if admin_info else None
 
-        if refresh is saved and role:
-            access = await create_access_token(identity=saved.key, role=role, app=request.app)
-            return json(dict(msg="refresh success", access=access), 201)
+        if saved and role and refresh == saved.refresh_token:
+            access = await create_access_token(identity=saved.admin_id, role=role, app=request.app)
+            return json(dict(msg="refresh succeed", access=access), 201)
 
         else:
             raise Forbidden("incorrect refresh token")
 
     async def logout(self, request):
-        refresh = request.headers.get("X-Refresh-Token").split("Bearer ")[1]
+        try:
+            refresh = request.headers.get("X-Refresh-Token").split("Bearer ")[1]
+        except IndexError:
+            raise BadRequest("missing 'Bearer '")
+
         saved = await self.cache_repo.get_by_refresh(refresh)
 
-        if refresh is saved:
+        if saved and refresh == saved.refresh_token:
             await self.cache_repo.delete(saved)
-            return json(dict(msg="logout success"), 202)
+            return json(dict(msg="logout succeed"), 202)
 
         else:
             raise Forbidden("incorrect refresh token")

--- a/chanel/app.py
+++ b/chanel/app.py
@@ -25,7 +25,8 @@ def create_app():
     _app.blueprint(admin_blueprint)
 
     _app.config['JWT_SECRET_KEY'] = settings.jwt_secret_key
-    _app.config['JWT_ACCESS_TOKEN_EXPIRES'] = datetime.timedelta(days=int(settings.jwt_access_expire))
+    _app.config['JWT_ACCESS_TOKEN_EXPIRES'] = datetime.timedelta(int(settings.jwt_access_expire))
+    _app.config['JWT_REFRESH_TOKEN_EXPIRES'] = datetime.timedelta(int(settings.jwt_refresh_expire))
     _app.config['RBAC_ENABLE'] = True
 
     JWTManager(_app)

--- a/chanel/applicant/controller/auth.py
+++ b/chanel/applicant/controller/auth.py
@@ -1,24 +1,53 @@
 from sanic import Blueprint
-from sanic.request import Request
 from sanic.views import HTTPMethodView
+
+from chanel.common.client.http import HTTPClient
+from chanel.common import json_verify, header_verify
+from chanel.common.client.redis import RedisConnection
+from chanel.applicant.service.auth import ApplicantService
+from chanel.common.external_sevice import ExternalServiceRepository
+from chanel.applicant.domain.applicant import ApplicantCacheRepository
 
 auth_bp: Blueprint = Blueprint("applicant_auth")
 
 
 class CreateApplicantToken(HTTPMethodView):
+    decorators = [json_verify(dict(email=str, password=str))]
 
-    def post(self, request: Request):
-        ...
+    service = ApplicantService(
+        ExternalServiceRepository(HTTPClient),
+        ApplicantCacheRepository(RedisConnection)
+    )
+
+    async def post(self, request):
+        response = await self.service.login(request)
+
+        return response
 
 
 class RefreshApplicantToken(HTTPMethodView):
-    def post(self, request: Request):
-        ...
+    decorators = [header_verify(["X-Refresh-Token"])]
+
+    service = ApplicantService(
+        ExternalServiceRepository(HTTPClient),
+        ApplicantCacheRepository(RedisConnection)
+    )
+
+    async def post(self, request):
+        response = await self.service.refresh(request)
+
+        return response
 
 
 class DestroyApplicantToken(HTTPMethodView):
-    def post(self, request: Request):
-        ...
+    decorators = [header_verify(["X-Refresh-Token"])]
+
+    service = ApplicantService(None, ApplicantCacheRepository(RedisConnection))
+
+    async def delete(self, request):
+        response = await self.service.logout(request)
+
+        return response
 
 
 auth_bp.add_route(CreateApplicantToken.as_view(), "/login")

--- a/chanel/applicant/controller/signup.py
+++ b/chanel/applicant/controller/signup.py
@@ -1,24 +1,45 @@
 from sanic import Blueprint
 from sanic.request import Request
 from sanic.views import HTTPMethodView
-from sanic.response import HTTPResponse
+from sanic.response import HTTPResponse, json
+
+from chanel.applicant.domain.applicant import ApplicantCacheRepository
+from chanel.applicant.service.signup import SignUpService
+from chanel.common import json_verify, query_parameter_verify
+from chanel.common.client.http import HTTPClient
+from chanel.common.client.redis import RedisConnection
+from chanel.common.external_sevice import ExternalServiceRepository
 
 signup_bp: Blueprint = Blueprint("applicant_signup")
 
 
 class CreateApplicantTempAccount(HTTPMethodView):
 
-    def post(self, request: Request) -> HTTPResponse:
-        ...
+    async def post(self, request: Request) -> HTTPResponse:
+        return json(dict(msg="say hello"), 200)
+
+
+class VerifyApplicantSignUpCode(HTTPMethodView):
+    decorators = [query_parameter_verify(["code"])]
+
+    async def get(self, request: Request) -> HTTPResponse:
+        return json(dict(msg="say hello"), 200)
 
 
 class VerifyApplicantEmail(HTTPMethodView):
-    def get(self, request: Request) -> HTTPResponse:
-        ...
+    decorators = [json_verify({"email": str})]
 
-    def post(self, request: Request) -> HTTPResponse:
-        ...
+    service = SignUpService(
+        ExternalServiceRepository(HTTPClient),
+        ApplicantCacheRepository(RedisConnection)
+    )
+
+    async def post(self, request: Request) -> HTTPResponse:
+        response = await self.service.send_verify_email(request)
+
+        return response
 
 
 signup_bp.add_route(CreateApplicantTempAccount.as_view(), "/signup")
+signup_bp.add_route(VerifyApplicantSignUpCode.as_view(), "/signup/verify")
 signup_bp.add_route(VerifyApplicantEmail.as_view(), "/signup/verify")

--- a/chanel/applicant/domain/applicant.py
+++ b/chanel/applicant/domain/applicant.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
+from typing import Type
 
-import ujson
-
+from chanel.common.client.redis import RedisConnection
 from chanel.common.domain.entity import BaseEntityClass
 
 
@@ -12,8 +12,39 @@ class Applicant(BaseEntityClass):
 
     @property
     def key(self) -> str:
-        return f"chanel:applicant:{self.email}"
+        return f"chanel:applicant:refresh:{self.email}"
 
     @property
     def value(self) -> str:
-        return ujson.dumps(self.__dict__)
+        return f"chanel:applicant:refresh:{self.refresh_token}"
+
+    @classmethod
+    def data_to_entity(cls, email, refresh_token):
+        if type(email) == bytes:
+            email = email.split(b':')[3].decode()
+
+        if type(refresh_token) == bytes:
+            refresh_token = refresh_token.split(b':')[3].decode()
+
+        return Applicant(email, refresh_token)
+
+
+class ApplicantCacheRepository:
+    def __init__(self, client: Type[RedisConnection]):
+        self.client = client
+
+    async def save(self, applicant: Applicant, expire: int = None) -> None:
+        await self.client.set(applicant.key, applicant.value, expire, pair=True)
+
+    async def delete(self, applicant: Applicant) -> None:
+        await self.client.delete(applicant.key, pair=True)
+
+    async def get_by_email(self, email: str) -> Applicant:
+        refresh = await self.client.get(f"chanel:applicant:refresh:{email}")
+
+        return Applicant.data_to_entity(email, refresh) if refresh else None
+
+    async def get_by_refresh(self, refresh: str) -> Applicant:
+        email = await self.client.get(f"chanel:applicant:refresh:{refresh}")
+
+        return Applicant.data_to_entity(email, refresh) if email else None

--- a/chanel/applicant/domain/temp_applicant.py
+++ b/chanel/applicant/domain/temp_applicant.py
@@ -1,18 +1,59 @@
 from dataclasses import dataclass
+from secrets import token_urlsafe
+from typing import Type
 
-import ujson
-
+from chanel.common.client.redis import RedisConnection
 from chanel.common.domain.entity import BaseEntityClass
 
 
 @dataclass
 class TempApplicant(BaseEntityClass):
     email: str
+    verify_code: str
+
+    def __init__(self, email: str, verify_code):
+        self.email = email
+        self.verify_code = verify_code
 
     @property
     def key(self) -> str:
-        return f"chanel:temp_applicant:{self.email}"
+        return f"chanel:temp_applicant:verify:{self.email}"
 
     @property
     def value(self) -> str:
-        return ujson.dumps(self.__dict__)
+        return f"chanel:temp_applicant:verify{self.verify_token}"
+
+    @classmethod
+    def generate_verify_code(cls):
+        cls.verify_code = token_urlsafe()
+
+    @classmethod
+    def data_to_entity(cls, email, verify_code):
+        if type(email) == bytes:
+            email = email.split(b':')[3].decode()
+
+        if type(verify_code) == bytes:
+            verify_code = verify_code.split(b':')[3].decode()
+
+        return TempApplicant(email, verify_code)
+
+
+class TempApplicantCacheRepository:
+    def __init__(self, client: Type[RedisConnection]):
+        self.client = client
+
+    async def save(self, temp_applicant: TempApplicant, expire: int = None) -> None:
+        await self.client.set(temp_applicant.key, temp_applicant.value, expire, pair=True)
+
+    async def delete(self, temp_applicant: TempApplicant) -> None:
+        await self.client.delete(temp_applicant.key, pair=True)
+
+    async def get_by_email(self, email: str) -> TempApplicant:
+        refresh = await self.client.get(f"chanel:temp_applicant:verify:{email}")
+
+        return TempApplicant.data_to_entity(email, refresh) if refresh else None
+
+    async def get_by_refresh(self, verify_code: str) -> TempApplicant:
+        email = await self.client.get(f"chanel:applicant:verify:{verify_code}")
+
+        return TempApplicant.data_to_entity(email, verify_code) if email else None

--- a/chanel/applicant/service/auth.py
+++ b/chanel/applicant/service/auth.py
@@ -1,0 +1,70 @@
+from sanic.response import json
+from sanic_jwt_extended import create_refresh_token, create_access_token
+
+from chanel.applicant.domain.applicant import Applicant, ApplicantCacheRepository
+from chanel.common.constant import APPLICANT
+from chanel.common.exception import Forbidden, BadRequest
+from chanel.common.external_sevice import ExternalServiceRepository
+
+
+class ApplicantService:
+    external_repo: ExternalServiceRepository = None
+    cache_repo: ApplicantCacheRepository = None
+
+    def __init__(self, external_repo: ExternalServiceRepository = None, cache_repo: ApplicantCacheRepository = None):
+        self.external_repo = external_repo
+        self.cache_repo = cache_repo
+
+    async def login(self, request):
+        email = request.json.get("email")
+        password = request.json.get("password")
+
+        authorized = await self.external_repo.get_applicant_auth_from_hermes(email, password)
+
+        if authorized:
+            saved_refresh = await self.cache_repo.get_by_email(email)
+            if saved_refresh:
+                await self.cache_repo.delete(saved_refresh)
+
+            access = await create_access_token(identity=email, role=APPLICANT, app=request.app)
+            refresh = await create_refresh_token(identity=email, app=request.app)
+
+            await self.cache_repo.save(
+                Applicant(email, refresh), int(request.app.config.JWT_REFRESH_TOKEN_EXPIRES.total_seconds())
+            )
+
+            return json(dict(msg="login success", access=access, refresh=refresh), 201)
+
+        else:
+            raise Forbidden("Can not find match applicant info")
+
+    async def refresh(self, request):
+        try:
+            refresh = request.headers.get("X-Refresh-Token").split("Bearer ")[1]
+        except IndexError:
+            raise BadRequest("missing 'Bearer '")
+
+        saved = await self.cache_repo.get_by_refresh(refresh)
+        print(saved)
+
+        if saved and refresh == saved.refresh_token:
+            access = await create_access_token(identity=saved.email, role=APPLICANT, app=request.app)
+            return json(dict(msg="refresh succeed", access=access), 201)
+
+        else:
+            raise Forbidden("incorrect refresh token")
+
+    async def logout(self, request):
+        try:
+            refresh = request.headers.get("X-Refresh-Token").split("Bearer ")[1]
+        except IndexError:
+            raise BadRequest("missing 'Bearer '")
+
+        saved = await self.cache_repo.get_by_refresh(refresh)
+
+        if not saved or refresh is not saved.refresh_token:
+            raise Forbidden("incorrect refresh token")
+
+        await self.cache_repo.delete(saved)
+
+        return json(dict(msg="logout succeed"), 202)

--- a/chanel/applicant/service/auth.py
+++ b/chanel/applicant/service/auth.py
@@ -67,4 +67,4 @@ class ApplicantService:
 
         await self.cache_repo.delete(saved)
 
-        return json(dict(msg="logout succeed"), 202)
+        return json(dict(msg="logout succeed"), 200)

--- a/chanel/common/__init__.py
+++ b/chanel/common/__init__.py
@@ -1,7 +1,8 @@
+from datetime import timedelta
 from functools import wraps
 from typing import List
 
-from common.exception import BadRequest
+from chanel.common.exception import BadRequest
 
 
 def json_verify(scheme: dict):
@@ -18,7 +19,9 @@ def json_verify(scheme: dict):
             response = await f(request, *args, **kwargs)
 
             return response
+
         return decorated_function
+
     return decorator
 
 
@@ -36,5 +39,30 @@ def header_verify(headers: List[str]):
             response = await f(request, *args, **kwargs)
 
             return response
+
         return decorated_function
+
+    return decorator
+
+
+def query_parameter_verify(query_strings: List[str]):
+    def decorator(f):
+        @wraps(f)
+        async def decorated_function(request, *args, **kwargs):
+            if not request.args:
+                raise BadRequest("please check query strings")
+
+            print(request.query_args)
+
+            for query_string in query_strings:
+                for query_args in request.query_args:
+                    if query_string not in query_args:
+                        raise BadRequest("invalid query string syntax detected")
+
+            response = await f(request, *args, **kwargs)
+
+            return response
+
+        return decorated_function
+
     return decorator

--- a/chanel/common/client/http.py
+++ b/chanel/common/client/http.py
@@ -1,3 +1,5 @@
+import ujson
+
 from aiohttp import ClientSession, TCPConnector, ClientTimeout
 
 
@@ -29,24 +31,27 @@ class HTTPClient:
         session = await cls.get_session()
 
         async with session.get(
-            url, params=kwargs
+                url, **kwargs
         ) as response:
-            return dict(data=await response.json(), status=response.status)
+            data = await response.read()
+            return dict(data=ujson.loads(data), status=response.status)
 
     @classmethod
     async def post(cls, url: str, **kwargs) -> dict:
         session = await cls.get_session()
 
         async with session.post(
-            url, params=kwargs
+                url, **kwargs
         ) as response:
-            return dict(data=await response.json(), status=response.status)
+            data = await response.read()
+            return dict(data=ujson.loads(data), status=response.status)
 
     @classmethod
     async def patch(cls, url: str, **kwargs) -> dict:
         session = await cls.get_session()
 
         async with session.patch(
-            url, params=kwargs
+                url, **kwargs
         ) as response:
-            return dict(data=await response.json(), status=response.status)
+            data = await response.read()
+            return dict(data=ujson.loads(data), status=response.status)

--- a/chanel/common/client/redis.py
+++ b/chanel/common/client/redis.py
@@ -7,7 +7,7 @@ class RedisConnection:
     _redis: Redis = None
 
     @classmethod
-    async def init(cls, connection_info):
+    async def init(cls, connection_info) -> None:
         await cls.get_redis_pool(connection_info)
 
     @classmethod
@@ -18,13 +18,17 @@ class RedisConnection:
         return cls._redis
 
     @classmethod
-    async def destroy(cls):
+    async def destroy(cls) -> None:
 
         if cls._redis:
             cls._redis.close()
             await cls._redis.wait_closed()
 
         cls._redis = None
+
+    @classmethod
+    async def flush_all(cls) -> None:
+        await cls._redis.flushall()
 
     @classmethod
     async def get(cls, key: str):

--- a/chanel/common/client/vault.py
+++ b/chanel/common/client/vault.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 from hvac import Client
 from hvac.exceptions import InvalidRequest
+
 from sanic.log import logger
 
 from chanel.common.constant import GITHUB_TOKEN, RUN_ENV, VAULT_ADDRESS, SERVICE_NAME
@@ -27,6 +28,9 @@ class VaultClient:
 
     @classmethod
     def __getattr__(cls, item: str):
+        if not cls.vault_client:
+            cls.initialize()
+
         try:
             return cls.vault_client.read(f"/service-secret/{RUN_ENV}/{SERVICE_NAME}")["data"][item]
 
@@ -56,6 +60,10 @@ class VaultClient:
     @property
     def jwt_refresh_expire(self):
         return self.vault_client.read(f"/service-secret/{RUN_ENV}/jwt-key")["data"]["refresh_expire"]
+
+    @property
+    def sendgrid_api_key(self):
+        return self.vault_client.read(f"/secret/sendgrid")["data"]["API_KEY"]
 
 
 class Setting:
@@ -87,6 +95,10 @@ class Setting:
     @property
     def jwt_refresh_expire(self):
         return self.vault_client.jwt_refresh_expire
+
+    @property
+    def sendgrid_api_key(self):
+        return self.vault_client.sendgrid_api_key
 
     DEBUG = False if RUN_ENV == "prod" else True
 

--- a/chanel/common/constant.py
+++ b/chanel/common/constant.py
@@ -1,14 +1,19 @@
+from datetime import timedelta
 from os import environ
 
 GITHUB_TOKEN = environ.get("GITHUB_TOKEN")
 VAULT_ADDRESS = environ.get("VAULT_ADDRESS")
-GATEWAY_ADDRESS = environ.get("GATEWAY_ADDRESS")
 RUN_ENV = environ.get("RUN_ENV")
 SERVICE_NAME = environ.get("SERVICE_NAME")
 API_VER = environ.get("API_VER", "v1")
 
-CREATE_NEW_APPLICANT = GATEWAY_ADDRESS + "/applicant"
-ONE_APPLICANT = GATEWAY_ADDRESS + "/applicant/{0}"
-GET_APPLICANT_AUTH = GATEWAY_ADDRESS + "/applicant/{0}/authorization"
-ONE_ADMIN = GATEWAY_ADDRESS + "/admin/{0}"
-GET_ADMIN_AUTH = GATEWAY_ADDRESS + "/admin/{0}/authorization"
+APPLICANT = "Applicant"
+HERMES = "http://hermes/api/v1"
+CREATE_NEW_APPLICANT = HERMES + "/applicant"
+ONE_APPLICANT = HERMES + "/applicant/{0}"
+GET_APPLICANT_AUTH = HERMES + "/applicant/{0}/authorization"
+ONE_ADMIN = HERMES + "/admin/{0}"
+GET_ADMIN_AUTH = HERMES + "/admin/{0}/authorization"
+
+VERIFY_EMAIL_TITLE = "[대덕소프트웨어마이스터고등학교] 입학전형시스템 회원가입 인증코드"
+VERIFY_EMAIL_CONTENT = "대덕소프트웨어마이스터고등학교 입학전형시스템에 가입하기 위해 다음 코드를 입력해주세요. %s"

--- a/chanel/common/external_sevice.py
+++ b/chanel/common/external_sevice.py
@@ -1,7 +1,8 @@
-from ujson import dumps, loads
+from ujson import loads
 
+from chanel.applicant.domain.applicant import Applicant
 from chanel.common.client.http import HTTPClient
-from chanel.common.constant import GET_ADMIN_AUTH, ONE_ADMIN
+from chanel.common.constant import GET_ADMIN_AUTH, ONE_ADMIN, GET_APPLICANT_AUTH, ONE_APPLICANT
 from chanel.common.exception import BadRequest, Unauthorized, Forbidden, NotFound
 
 
@@ -11,26 +12,47 @@ class ExternalServiceRepository:
     def __init__(self, client):
         self.client = client
 
-    async def get_admin_auth_from_gateway(self, admin_id: str, password: str) -> bool:
-        response = await self.client.post(url=GET_ADMIN_AUTH.format(admin_id), json=dumps(dict(password=password)))
+    async def get_admin_auth_from_hermes(self, admin_id: str, password: str) -> bool:
+        response = await self.client.post(url=GET_ADMIN_AUTH.format(admin_id), json={"password": password})
 
         if response["status"] == 200:
             return True
 
         elif response["status"] == 400:
-            raise BadRequest("bad request from gateway")
+            raise BadRequest("bad request from inter-service")
 
         elif response["status"] == 403:
-            raise Forbidden("authorization failed from gateway")
+            raise Forbidden("authorization failed from inter-service")
 
-    async def get_admin_info_from_gateway(self, admin_id: str):
-        response = await self.client.get(url=ONE_ADMIN.format(admin_id), )
+    async def get_admin_info_from_hermes(self, admin_id: str):
+        response = await self.client.get(url=ONE_ADMIN.format(admin_id))
+
+        if response["status"] == 200:
+            return response["data"]
+
+        elif response["status"] == 401:
+            raise Unauthorized("authentication failed from inter-service")
+
+        elif response["status"] == 404:
+            raise NotFound("admin not found from inter-service")
+
+    async def get_applicant_auth_from_hermes(self, email: str, password: str) -> bool:
+        response = await self.client.post(url=GET_APPLICANT_AUTH.format(email), json={"password": password})
+
+        if response["status"] == 200:
+            return True
+
+        elif response["status"] == 400:
+            raise BadRequest("bad request from inter-service")
+
+        elif response["status"] == 403:
+            raise Forbidden("authorization failed from inter-service")
+
+    async def get_applicant_info_from_hermes(self, email: str) -> Applicant:
+        response = await self.client.get(url=ONE_APPLICANT.format(email))
 
         if response["status"] == 200:
             return loads(response["data"])
 
         elif response["status"] == 401:
-            raise Unauthorized("authentication failed from gateway")
-
-        elif response["status"] == 404:
-            raise NotFound("admin not found from gateway")
+            raise Unauthorized("authentication failed from inter-service")

--- a/chanel/common/mail.py
+++ b/chanel/common/mail.py
@@ -2,12 +2,14 @@ import re
 
 from sanic import Sanic
 from sanic.log import logger
-from sendgrid import SendGridAPIClient, ApiKeyIncludedException
+from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
 from python_http_client.exceptions import BadRequestsError, UnauthorizedError
 
+from chanel.common.client.vault import settings
 
-def send_email(to_email: str, title: str, content: str, app: Sanic):
+
+def send_email(to_email: str, title: str, content: str):
     message = Mail(
         from_email="entrydsm@dsm.hs.kr",
         to_emails=to_email,
@@ -16,7 +18,7 @@ def send_email(to_email: str, title: str, content: str, app: Sanic):
     )
 
     try:
-        client = SendGridAPIClient(app.config["SENDGRID_API_KEY"])
+        client = SendGridAPIClient(settings.sendgrid_api_key)
         response = client.send(message)
 
         return response.status_code

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,17 @@
+import pytest
+
+from chanel.common.client.redis import RedisConnection
+
+
+@pytest.fixture(scope="function")
+async def redis_management(redis_DB, redis_proc):
+    conn_info = {
+        "address": f"redis://:@{redis_proc.host}:{redis_proc.port}",
+        "minsize": 5,
+        "maxsize": 10,
+    }
+
+    await RedisConnection.init(conn_info)
+    await RedisConnection.flush_all()
+    yield
+    await RedisConnection.destroy()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,7 +1,7 @@
 import pytest
 from aioredis.errors import RedisError
 
-from chanel.redis import RedisConnection
+from chanel.common.client.redis import RedisConnection
 
 
 @pytest.mark.asyncio
@@ -14,7 +14,7 @@ from chanel.redis import RedisConnection
         ("flush_all", {}),
     ],
 )
-async def test_cache_connection_interface(cache_method, param, cache_manage):
+async def test_cache_connection_interface(cache_method, param, redis_management):
     try:
         await getattr(RedisConnection, cache_method)(**param)
     except RedisError as e:


### PR DESCRIPTION
본 PR까지의 주요 변경사항은 다음과 같습니다.
- MSA 환경에서 Chanel 서비스는 게이트웨이로 요청을 보내지 않습니다. 따라서 Hermes에 직접 요청을 보내도록 로직을 수정했습니다.
- 최대한 response status code가 500번대가 나오지 않도록 하기 위해 예외처리에 신경썼습니다. 허나 if 분기문으로 떡칠되어 있는 것 같아 다음 PR떄 custom exception을 활용, try-except문으로 대체하도록 하겠습니다.
- 이메일 주소 인증 메일을 발송하기 위한 Sendgrid api key를 불러오는 코드를 작성했습니다.